### PR TITLE
feat(stripe): Complete Stripe integration with deduplication and Connect

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -139,8 +139,18 @@ STRIPE_PUBLISHABLE_KEY=pk_test_xxx
 STRIPE_WEBHOOK_SECRET=whsec_xxx
 
 # Stripe Price IDs (create in Stripe Dashboard > Products)
-STRIPE_PRICE_PRO=price_xxx          # $29/month Pro plan
-STRIPE_PRICE_ENTERPRISE=price_xxx   # $99/month Enterprise plan
+# Base prices are the platform fee, seat prices are per-additional-seat
+STRIPE_PRICE_PRO_BASE=price_xxx           # Pro base price ($29/month)
+STRIPE_PRICE_PRO_SEAT=price_xxx           # Pro per-seat price ($10/month)
+STRIPE_PRICE_ENTERPRISE_BASE=price_xxx    # Enterprise base price ($99/month)
+STRIPE_PRICE_ENTERPRISE_SEAT=price_xxx    # Enterprise per-seat price ($25/month)
+
+# Stripe Connect (Marketplace)
+# =============================================================================
+# Webhook secret for Connect events (account updates, payouts, transfers)
+STRIPE_CONNECT_WEBHOOK_SECRET=whsec_xxx
+# Frontend URL for Connect onboarding redirects
+FRONTEND_URL=http://localhost:3000
 
 # =============================================================================
 # Application Settings

--- a/repotoire/db/models/__init__.py
+++ b/repotoire/db/models/__init__.py
@@ -33,6 +33,7 @@ from .billing import (
     AddonType,
     BestOfNUsage,
     CustomerAddon,
+    ProcessedWebhookEvent,
     Subscription,
     SubscriptionStatus,
     UsageRecord,

--- a/repotoire/web/src/app/dashboard/publisher/connect/complete/page.tsx
+++ b/repotoire/web/src/app/dashboard/publisher/connect/complete/page.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+/**
+ * Stripe Connect Onboarding Complete Page
+ *
+ * Users are redirected here after completing Stripe Connect onboarding.
+ * This page checks their account status and shows success/next steps.
+ */
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { CheckCircle2, AlertCircle, Loader2, ExternalLink, ArrowRight } from 'lucide-react';
+import { useConnectStatus } from '@/lib/marketplace-hooks';
+
+export default function ConnectCompletePage() {
+  const router = useRouter();
+  const { data: status, isLoading, error, mutate } = useConnectStatus();
+
+  // Refresh status on mount to get latest from Stripe
+  useEffect(() => {
+    mutate();
+  }, [mutate]);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-[400px]">
+        <div className="text-center space-y-4">
+          <Loader2 className="h-8 w-8 animate-spin text-muted-foreground mx-auto" />
+          <p className="text-muted-foreground">Checking your account status...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="max-w-2xl mx-auto space-y-6">
+        <Alert variant="destructive">
+          <AlertCircle className="h-4 w-4" />
+          <AlertTitle>Error checking account status</AlertTitle>
+          <AlertDescription>
+            We couldn&apos;t verify your Stripe Connect account. Please try again.
+          </AlertDescription>
+        </Alert>
+        <Button onClick={() => mutate()}>Retry</Button>
+      </div>
+    );
+  }
+
+  const isComplete = status?.onboarding_complete;
+  const chargesEnabled = status?.charges_enabled;
+  const payoutsEnabled = status?.payouts_enabled;
+
+  return (
+    <div className="max-w-2xl mx-auto space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold">Stripe Connect Setup</h1>
+        <p className="text-muted-foreground">Your publisher payout account status</p>
+      </div>
+
+      {isComplete ? (
+        <>
+          <Alert className="border-green-500 bg-green-50 dark:bg-green-950">
+            <CheckCircle2 className="h-4 w-4 text-green-600" />
+            <AlertTitle className="text-green-800 dark:text-green-200">
+              Onboarding Complete!
+            </AlertTitle>
+            <AlertDescription className="text-green-700 dark:text-green-300">
+              Your Stripe Connect account is set up and ready to receive payouts.
+            </AlertDescription>
+          </Alert>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Account Status</CardTitle>
+              <CardDescription>Your payout capabilities</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="flex items-center justify-between">
+                <span>Accept payments</span>
+                <span className={chargesEnabled ? 'text-green-600' : 'text-yellow-600'}>
+                  {chargesEnabled ? 'Enabled' : 'Pending verification'}
+                </span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span>Receive payouts</span>
+                <span className={payoutsEnabled ? 'text-green-600' : 'text-yellow-600'}>
+                  {payoutsEnabled ? 'Enabled' : 'Pending verification'}
+                </span>
+              </div>
+            </CardContent>
+          </Card>
+
+          <div className="flex gap-4">
+            {status?.dashboard_url && (
+              <Button variant="outline" asChild>
+                <a href={status.dashboard_url} target="_blank" rel="noopener noreferrer">
+                  Stripe Dashboard <ExternalLink className="ml-2 h-4 w-4" />
+                </a>
+              </Button>
+            )}
+            <Button onClick={() => router.push('/dashboard/marketplace/publish')}>
+              Publish Your First Asset <ArrowRight className="ml-2 h-4 w-4" />
+            </Button>
+          </div>
+        </>
+      ) : (
+        <>
+          <Alert className="border-yellow-500 bg-yellow-50 dark:bg-yellow-950">
+            <AlertCircle className="h-4 w-4 text-yellow-600" />
+            <AlertTitle className="text-yellow-800 dark:text-yellow-200">
+              Onboarding Incomplete
+            </AlertTitle>
+            <AlertDescription className="text-yellow-700 dark:text-yellow-300">
+              Your Stripe Connect setup is not complete. Please finish the onboarding process.
+            </AlertDescription>
+          </Alert>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Complete Your Setup</CardTitle>
+              <CardDescription>
+                Stripe needs additional information to enable payouts
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <p className="text-muted-foreground mb-4">
+                You may need to provide additional details such as business information,
+                bank account details, or identity verification.
+              </p>
+              <Button onClick={() => router.push('/dashboard/publisher/connect/refresh')}>
+                Continue Setup <ArrowRight className="ml-2 h-4 w-4" />
+              </Button>
+            </CardContent>
+          </Card>
+        </>
+      )}
+    </div>
+  );
+}

--- a/repotoire/web/src/app/dashboard/publisher/connect/refresh/page.tsx
+++ b/repotoire/web/src/app/dashboard/publisher/connect/refresh/page.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+/**
+ * Stripe Connect Refresh Page
+ *
+ * Users are redirected here when their onboarding link expires.
+ * This page generates a new link and redirects them back to Stripe.
+ */
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { AlertCircle, Loader2, RefreshCw, ExternalLink } from 'lucide-react';
+import { useGetOnboardingLink, useConnectStatus } from '@/lib/marketplace-hooks';
+
+export default function ConnectRefreshPage() {
+  const router = useRouter();
+  const { data: status, isLoading: statusLoading } = useConnectStatus();
+  const { trigger: getLink, isMutating, error } = useGetOnboardingLink();
+  const [onboardingUrl, setOnboardingUrl] = useState<string | null>(null);
+
+  // If already complete, redirect to complete page
+  useEffect(() => {
+    if (status?.onboarding_complete) {
+      router.push('/dashboard/publisher/connect/complete');
+    }
+  }, [status, router]);
+
+  const handleGetNewLink = async () => {
+    try {
+      const result = await getLink();
+      if (result?.onboarding_url) {
+        setOnboardingUrl(result.onboarding_url);
+      }
+    } catch (err) {
+      console.error('Failed to get onboarding link:', err);
+    }
+  };
+
+  const handleContinueToStripe = () => {
+    if (onboardingUrl) {
+      window.location.href = onboardingUrl;
+    }
+  };
+
+  if (statusLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-[400px]">
+        <div className="text-center space-y-4">
+          <Loader2 className="h-8 w-8 animate-spin text-muted-foreground mx-auto" />
+          <p className="text-muted-foreground">Checking your account status...</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold">Continue Setup</h1>
+        <p className="text-muted-foreground">
+          Your previous onboarding link has expired or you need to continue setup
+        </p>
+      </div>
+
+      {error && (
+        <Alert variant="destructive">
+          <AlertCircle className="h-4 w-4" />
+          <AlertTitle>Error getting new link</AlertTitle>
+          <AlertDescription>
+            {error instanceof Error ? error.message : 'Failed to generate a new onboarding link. Please try again.'}
+          </AlertDescription>
+        </Alert>
+      )}
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Stripe Connect Onboarding</CardTitle>
+          <CardDescription>
+            Get a new link to continue setting up your payout account
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {!onboardingUrl ? (
+            <>
+              <p className="text-muted-foreground">
+                Click the button below to generate a new onboarding link. You&apos;ll be redirected
+                to Stripe to complete your account setup.
+              </p>
+              <Button
+                onClick={handleGetNewLink}
+                disabled={isMutating}
+              >
+                {isMutating ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Generating Link...
+                  </>
+                ) : (
+                  <>
+                    <RefreshCw className="mr-2 h-4 w-4" />
+                    Get New Onboarding Link
+                  </>
+                )}
+              </Button>
+            </>
+          ) : (
+            <>
+              <Alert className="border-green-500 bg-green-50 dark:bg-green-950">
+                <AlertTitle className="text-green-800 dark:text-green-200">
+                  Link Generated!
+                </AlertTitle>
+                <AlertDescription className="text-green-700 dark:text-green-300">
+                  Click below to continue to Stripe and complete your setup.
+                </AlertDescription>
+              </Alert>
+              <Button onClick={handleContinueToStripe} className="w-full">
+                Continue to Stripe <ExternalLink className="ml-2 h-4 w-4" />
+              </Button>
+            </>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>What You&apos;ll Need</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ul className="list-disc list-inside space-y-2 text-muted-foreground">
+            <li>Business information (if applicable)</li>
+            <li>Bank account details for payouts</li>
+            <li>Government-issued ID for identity verification</li>
+            <li>Tax information (SSN/EIN in the US)</li>
+          </ul>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/repotoire/web/src/lib/marketplace-api.ts
+++ b/repotoire/web/src/lib/marketplace-api.ts
@@ -952,6 +952,50 @@ export const marketplaceApi = {
     params.set('days', String(days));
     return request(`/marketplace/analytics/assets/@${publisherSlug}/${assetSlug}/trends?${params}`);
   },
+
+  // ==========================================
+  // Stripe Connect (Publisher Payouts)
+  // ==========================================
+
+  /**
+   * Start Stripe Connect onboarding to become a publisher.
+   * Returns the onboarding URL to redirect the user to.
+   */
+  createConnectAccount: async (): Promise<{ stripe_account_id: string; onboarding_url: string }> => {
+    return request('/marketplace/publishers/connect', {
+      method: 'POST',
+    });
+  },
+
+  /**
+   * Get Stripe Connect account status.
+   */
+  getConnectStatus: async (): Promise<{
+    stripe_account_id: string | null;
+    charges_enabled: boolean;
+    payouts_enabled: boolean;
+    onboarding_complete: boolean;
+    dashboard_url: string | null;
+  }> => {
+    return request('/marketplace/publishers/connect/status');
+  },
+
+  /**
+   * Get a new onboarding link if the previous one expired.
+   */
+  getOnboardingLink: async (): Promise<{ onboarding_url: string }> => {
+    return request('/marketplace/publishers/connect/onboarding');
+  },
+
+  /**
+   * Get Connect account balance.
+   */
+  getConnectBalance: async (): Promise<{
+    available: Array<{ amount: number; currency: string }>;
+    pending: Array<{ amount: number; currency: string }>;
+  }> => {
+    return request('/marketplace/publishers/connect/balance');
+  },
 };
 
 export { API_BASE_URL };


### PR DESCRIPTION
## Summary
- Add webhook event ID deduplication for idempotent processing
- Add new webhook handlers:
  - `handle_trial_will_end()` - Trial ending notifications
  - `handle_charge_refunded()` - Refund audit logging
  - `handle_payout_failed()` - Connect payout failure handling
- Add Stripe Connect return URL handlers:
  - `/dashboard/publisher/connect/complete` - Onboarding completion page
  - `/dashboard/publisher/connect/refresh` - Re-authenticate page
- Add Connect API functions and hooks for marketplace integration

## Test plan
- [ ] Verify webhook deduplication prevents duplicate processing
- [ ] Test trial_will_end webhook sends notifications
- [ ] Test charge.refunded webhook logs audit entries
- [ ] Test payout.failed webhook handles Connect failures
- [ ] Verify Connect complete page shows success state
- [ ] Verify Connect refresh page redirects to onboarding

🤖 Generated with [Claude Code](https://claude.com/claude-code)